### PR TITLE
Updating docker-compose to fix NMS launch error

### DIFF
--- a/nms/fbcnms-projects/magmalte/docker-compose.yml
+++ b/nms/fbcnms-projects/magmalte/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     image: mysql:5
     environment:
       MYSQL_ROOT_PASSWORD: 12345
-      MYSQL_DATABASE: nms
+      MYSQL_DATABASE_IF_NOT_EXIST: nms
       MYSQL_USER: nms
       MYSQL_PASSWORD: password
     restart: always


### PR DESCRIPTION
When launching NMS using ./scripts/dev_setup.sh, it complains that NMS user table not found. Adding MYSQL_DATABASE_IF_NOT_EXIST in place of  MYSQL_DATABASE in the docker-compose fixes this issue. Here's the specific error dump: 
# ./scripts/dev_setup.sh
Starting magmalte_mysql_1 ... done
yarn run v1.16.0
$ node -r '@fbcnms/babel-register' scripts/setPassword.js admin@magma.test password1234
{ SequelizeDatabaseError: Table 'nms.Users' doesn't exist
    at Query.formatError (/usr/src/node_modules/sequelize/lib/dialects/mysql/query.js:239:16)
    at Query.handler [as onResult] (/usr/src/node_modules/sequelize/lib/dialects/mysql/query.js:46:23)
    at Query.execute (/usr/src/node_modules/mysql2/lib/commands/command.js:30:14)
    at Connection.handlePacket (/usr/src/node_modules/mysql2/lib/connection.js:449:32)
    at PacketParser.Connection.packetParser.p [as onPacket] (/usr/src/node_modules/mysql2/lib/connection.js:72:12)
    at PacketParser.executeStart (/usr/src/node_modules/mysql2/lib/packet_parser.js:75:16)
    at Socket.Connection.stream.on.data (/usr/src/node_modules/mysql2/lib/connection.js:79:25)
    at Socket.emit (events.js:198:13)
    at addChunk (_stream_readable.js:288:12)
    at readableAddChunk (_stream_readable.js:269:11)
    at Socket.Readable.push (_stream_readable.js:224:10)
    at TCP.onStreamRead [as onread] (internal/stream_base_commons.js:94:17)
  name: 'SequelizeDatabaseError',